### PR TITLE
Update project to .NET 8

### DIFF
--- a/src/WebCrawlerSample.Tests/WebCrawlerSample.Tests.csproj
+++ b/src/WebCrawlerSample.Tests/WebCrawlerSample.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>WebCrawlerSample.Tests</Authors>
     <Copyright>WebCrawlerSample.Tests</Copyright>
@@ -12,27 +12,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cloud.Core.Testing" Version="3.1.3529.462" />
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="Cloud.Core.Testing" Version="23.10.10.15" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="FluentAssertions" Version="8.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.0.0-rc4" />
+    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.6.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebCrawlerSample/WebCrawlerSample.csproj
+++ b/src/WebCrawlerSample/WebCrawlerSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>WebCrawlerSample</PackageId>
     <Company>WebCrawlerSample</Company>
     <Authors>Robert McCabe</Authors>
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.32" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- target .NET 8 in sample and tests
- bump dependency versions for HtmlAgilityPack, Microsoft.Extensions.Http.Polly, and test packages

## Testing
- `dotnet restore WebCrawlerSample.sln` *(fails: Unable to find package Cloud.Core.Testing)*
- `dotnet build WebCrawlerSample.sln -c Release` *(fails: Unable to find package Cloud.Core.Testing)*
- `dotnet test WebCrawlerSample.sln` *(fails: Unable to find package Cloud.Core.Testing)*


------
https://chatgpt.com/codex/tasks/task_e_686a4f98addc832d83ab1271f50418b4