### PR TITLE
Rename crawler implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ public async Task DoWork()
 {
     var downloader = new Downloader();
     var parser = new HtmlParser();
-    var crawler = new WebCrawer(downloader, parser);
+    var crawler = new WebCrawler(downloader, parser);
     
     // Handle every time an event is fired.
     crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page)); 
@@ -168,7 +168,7 @@ The application structure is as follows:
            - CrawlerPage.cs
            - CrawlerResult.cs     
       / Services          
-           - Crawler.cs
+           - WebCrawler.cs
            - Downloader.cs          
            - HtmlParser.cs      
       - Program.cs

--- a/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
+++ b/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
@@ -15,7 +15,7 @@ namespace WebCrawlerSample.Tests.Integration
         {
             // Arrange
             var testSite = "https://www.crawler-test.com/";
-            var crawler = new WebCrawer(new Downloader(), new HtmlParser());
+            var crawler = new WebCrawler(new Downloader(), new HtmlParser());
             
             // Act
             var result = await crawler.RunAsync(testSite);

--- a/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
@@ -31,7 +31,7 @@ namespace WebCrawlerSample.Tests.Unit
 
             IDownloader downloader = new Downloader(fakeHandler);
             IHtmlParser parser = new HtmlParser();
-            var crawler = new WebCrawer(downloader, parser);
+            var crawler = new WebCrawler(downloader, parser);
 
             // Act 
             var crawlResult = await crawler.RunAsync(rootSite, 3);

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -21,7 +21,7 @@ namespace WebCrawlerSample
             IHtmlParser parser = new HtmlParser();
 
             // Initialise the crawler and hook into the crawled event.
-            var crawler = new WebCrawer(downloader, parser);
+            var crawler = new WebCrawler(downloader, parser);
             crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page));
 
             Console.WriteLine($"Crawling {startingUrl} to depth {maxDepth}\n");

--- a/src/WebCrawlerSample/Services/WebCrawler.cs
+++ b/src/WebCrawlerSample/Services/WebCrawler.cs
@@ -7,7 +7,10 @@ using WebCrawlerSample.Models;
 
 namespace WebCrawlerSample.Services
 {
-    public class WebCrawer
+    /// <summary>
+    /// Service used to crawl web pages starting from a root URL.
+    /// </summary>
+    public class WebCrawler
     {
         private readonly ConcurrentDictionary<string, CrawledPage> _pagesVisited = new ConcurrentDictionary<string, CrawledPage>();
         private readonly IDownloader _downloader;
@@ -15,7 +18,7 @@ namespace WebCrawlerSample.Services
 
         public event EventHandler<CrawledPage> PageCrawled; // event
 
-        public WebCrawer(IDownloader downloader, IHtmlParser parser)
+        public WebCrawler(IDownloader downloader, IHtmlParser parser)
         {
             _downloader = downloader;
             _parser = parser;


### PR DESCRIPTION
## Summary
- rename `Crawler.cs` to `WebCrawler.cs`
- rename `WebCrawer` class to `WebCrawler`
- update references in program and tests
- adjust documentation for new filename

## Testing
- `dotnet test src/WebCrawlerSample.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7e55dd9c832d89589639d71562f2