### PR TITLE
Add cancellation token support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ public async Task DoWork()
     crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page)); 
     
     // Run crawl!
-    var result = await crawler.RunAsync("https://www.crawler-test.com/", 3);
+    var result = await crawler.RunAsync("https://www.crawler-test.com/", 3, CancellationToken.None);
     
     ...
 }

--- a/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
+++ b/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using System.Net.Http;
@@ -22,7 +23,7 @@ namespace WebCrawlerSample.Tests.Integration
             var crawler = new WebCrawler(new Downloader(factory.Object), new HtmlParser());
             
             // Act
-            var result = await crawler.RunAsync(testSite);
+            var result = await crawler.RunAsync(testSite, cancellationToken: CancellationToken.None);
 
             // Assert
             result.MaxDepth.Should().Be(1);

--- a/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using WebCrawlerSample.Services;
@@ -38,7 +39,7 @@ namespace WebCrawlerSample.Tests.Unit
             var crawler = new WebCrawler(downloader, parser);
 
             // Act 
-            var crawlResult = await crawler.RunAsync(rootSite, 3);
+            var crawlResult = await crawler.RunAsync(rootSite, 3, CancellationToken.None);
             var rootPage = crawlResult.Links[$"{rootSite}/"];
             var page1 = crawlResult.Links[$"{rootSite}/page1"];
             var page2 = crawlResult.Links[$"{rootSite}/page2"];

--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using WebCrawlerSample.Services;
@@ -30,7 +31,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act 
-            var result = await downloader.GetContent(uri);
+            var result = await downloader.GetContent(uri, CancellationToken.None);
 
             // Assert
             result.Should().Be(content);
@@ -50,7 +51,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act 
-            var result = await downloader.GetContent(uri);
+            var result = await downloader.GetContent(uri, CancellationToken.None);
 
             // Assert
             result.Should().Be("");

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
@@ -43,10 +44,17 @@ namespace WebCrawlerSample
             var crawler = new WebCrawler(downloader, parser);
             crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page));
 
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (s, e) =>
+            {
+                e.Cancel = true;
+                cts.Cancel();
+            };
+
             Console.WriteLine($"Crawling {startingUrl} to depth {maxDepth}\n");
 
             // Run the crawler!
-            var result = await crawler.RunAsync(startingUrl, maxDepth);
+            var result = await crawler.RunAsync(startingUrl, maxDepth, cts.Token);
 
             Console.WriteLine($"Max depth: {result.MaxDepth}");
             Console.WriteLine($"Total links visited: {result.Links.Keys.Count}");

--- a/src/WebCrawlerSample/Services/Downloader.cs
+++ b/src/WebCrawlerSample/Services/Downloader.cs
@@ -2,6 +2,7 @@
 using Polly.Retry;
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WebCrawlerSample.Services
@@ -19,7 +20,7 @@ namespace WebCrawlerSample.Services
                 .WaitAndRetryAsync(3, i => TimeSpan.FromMilliseconds(300)); // Retry 3 times, with 300 millisecond delay.
         }
         
-        public async Task<string> GetContent(Uri site)
+        public async Task<string> GetContent(Uri site, CancellationToken cancellationToken)
         {
             try
             {
@@ -27,7 +28,7 @@ namespace WebCrawlerSample.Services
                 var client = _clientFactory.CreateClient("crawler");
                 return await _retryPolicy.ExecuteAsync(async () =>
                 {
-                    var response = await client.GetAsync(site);
+                    var response = await client.GetAsync(site, cancellationToken);
                     return await response.Content.ReadAsStringAsync();
                 });
             }
@@ -40,6 +41,6 @@ namespace WebCrawlerSample.Services
 
     public interface IDownloader
     {
-        Task<string> GetContent(Uri site);
+        Task<string> GetContent(Uri site, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- allow aborting crawl operations with CancellationToken
- pass token through to HttpClient requests
- handle Ctrl+C in console app
- update README example
- adjust tests for new signatures

## Testing
- `dotnet build src/WebCrawlerSample/WebCrawlerSample.csproj`
- `dotnet test src/WebCrawlerSample.sln` *(fails: Unable to find package Cloud.Core.Testing)*

------
https://chatgpt.com/codex/tasks/task_e_686d81cb1b50832d8179e6d344402e41