### PR TITLE
Add html validation to downloader

### DIFF
--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -24,7 +25,9 @@ namespace WebCrawlerSample.Tests.Unit
             // Arrange
             var uri = new Uri("http://contoso.com");
             var fakeHandler = new FakeResponseHandler();
-            fakeHandler.AddFakeResponse(uri, new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) });
+            var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+            fakeHandler.AddFakeResponse(uri, message);
             var client = new HttpClient(fakeHandler, disposeHandler: false);
             var factory = new Mock<IHttpClientFactory>();
             factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
@@ -54,7 +57,54 @@ namespace WebCrawlerSample.Tests.Unit
             var result = await downloader.GetContent(uri, CancellationToken.None);
 
             // Assert
-            result.Should().Be("");
+            result.Should().BeNull();
+        }
+
+        // Verify null returned when content type is not text/html.
+        [Fact]
+        public async Task Test_Downloader_GetContent_NotHtml()
+        {
+            // Arrange
+            var uri = new Uri("http://contoso.com");
+            var fakeHandler = new FakeResponseHandler();
+            var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ignored") };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+            fakeHandler.AddFakeResponse(uri, message);
+            var client = new HttpClient(fakeHandler, disposeHandler: false);
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+            var downloader = new Downloader(factory.Object);
+
+            // Act
+            var result = await downloader.GetContent(uri, CancellationToken.None);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        // Verify content larger than 100KB results in null.
+        [Fact]
+        public async Task Test_Downloader_GetContent_ContentTooLarge()
+        {
+            // Arrange
+            var uri = new Uri("http://contoso.com");
+            var content = new string('a', 102_401);
+            var fakeHandler = new FakeResponseHandler();
+            var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+            // Set explicit content length header
+            message.Content.Headers.ContentLength = content.Length;
+            fakeHandler.AddFakeResponse(uri, message);
+            var client = new HttpClient(fakeHandler, disposeHandler: false);
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+            var downloader = new Downloader(factory.Object);
+
+            // Act
+            var result = await downloader.GetContent(uri, CancellationToken.None);
+
+            // Assert
+            result.Should().BeNull();
         }
     }
 }

--- a/src/WebCrawlerSample/Services/Downloader.cs
+++ b/src/WebCrawlerSample/Services/Downloader.cs
@@ -29,6 +29,16 @@ namespace WebCrawlerSample.Services
                 return await _retryPolicy.ExecuteAsync(async () =>
                 {
                     var response = await client.GetAsync(site, cancellationToken);
+
+                    // Ensure only html content is processed
+                    if (response.Content?.Headers.ContentType?.MediaType != "text/html")
+                        return null;
+
+                    // Skip download if content length is greater than 100 KB
+                    if (response.Content.Headers.ContentLength.HasValue &&
+                        response.Content.Headers.ContentLength.Value > 102_400)
+                        return null;
+
                     return await response.Content.ReadAsStringAsync();
                 });
             }


### PR DESCRIPTION
## Summary
- ensure `Downloader` only processes `text/html`
- skip reading response body when content length > 100 KB
- update unit tests for downloader

## Testing
- `dotnet test src/WebCrawlerSample.sln` *(fails: Unable to restore Cloud.Core.Testing package)*

------
https://chatgpt.com/codex/tasks/task_e_686d88c44790832db22e4f5e51e3f09c