### PR TITLE
Add file download option to crawler

### DIFF
--- a/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
+++ b/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
@@ -23,7 +23,7 @@ namespace WebCrawlerSample.Tests.Integration
             var crawler = new WebCrawler(new Downloader(factory.Object), new HtmlParser());
             
             // Act
-            var result = await crawler.RunAsync(testSite, cancellationToken: CancellationToken.None);
+            var result = await crawler.RunAsync(testSite, maxDepth: 1, downloadFiles: false, cancellationToken: CancellationToken.None);
 
             // Assert
             result.MaxDepth.Should().Be(1);

--- a/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using WebCrawlerSample.Services;
+using WebCrawlerSample.Models;
 using Xunit;
 
 namespace WebCrawlerSample.Tests.Unit
@@ -39,7 +40,7 @@ namespace WebCrawlerSample.Tests.Unit
             var crawler = new WebCrawler(downloader, parser);
 
             // Act 
-            var crawlResult = await crawler.RunAsync(rootSite, 3, CancellationToken.None);
+            var crawlResult = await crawler.RunAsync(rootSite, 3, false, null, CancellationToken.None);
             var rootPage = crawlResult.Links[$"{rootSite}/"];
             var page1 = crawlResult.Links[$"{rootSite}/page1"];
             var page2 = crawlResult.Links[$"{rootSite}/page2"];
@@ -89,13 +90,15 @@ namespace WebCrawlerSample.Tests.Unit
                     InterlockedExtensions.Max(ref maxConcurrent, current);
                     await Task.Delay(10, token);
                     Interlocked.Decrement(ref concurrent);
-                    return uri.AbsoluteUri == $"{rootSite}/" ? html : string.Empty;
+                    var content = uri.AbsoluteUri == $"{rootSite}/" ? html : string.Empty;
+                    var data = System.Text.Encoding.UTF8.GetBytes(content);
+                    return new DownloadResult(content, data, "text/html");
                 });
 
             var crawler = new WebCrawler(downloaderMock.Object, parser);
 
             // Act
-            var result = await crawler.RunAsync(rootSite, 2, CancellationToken.None);
+            var result = await crawler.RunAsync(rootSite, 2, false, null, CancellationToken.None);
 
             // Assert
             result.Links.Count.Should().Be(11);

--- a/src/WebCrawlerSample/Models/DownloadResult.cs
+++ b/src/WebCrawlerSample/Models/DownloadResult.cs
@@ -1,0 +1,18 @@
+namespace WebCrawlerSample.Models
+{
+    public class DownloadResult
+    {
+        public string Content { get; }
+        public byte[] Data { get; }
+        public string MediaType { get; }
+
+        public DownloadResult(string content, byte[] data, string mediaType)
+        {
+            Content = content;
+            Data = data;
+            MediaType = mediaType;
+        }
+
+        public bool IsHtml => MediaType?.StartsWith("text/html") == true;
+    }
+}

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -16,9 +16,11 @@ namespace WebCrawlerSample
             // default site and depth before grabbing from args.
             var startingUrl = "https://www.crawler-test.com/";
             var maxDepth = 3;
+            var downloadFiles = false;
 
             if (args.Length > 0) startingUrl = args[0];
             if (args.Length > 1) maxDepth = Convert.ToInt32(args[1]);
+            if (args.Length > 2) bool.TryParse(args[2], out downloadFiles);
 
             // Setup dependencies for the crawler.
             var services = new ServiceCollection();
@@ -54,7 +56,7 @@ namespace WebCrawlerSample
             Console.WriteLine($"Crawling {startingUrl} to depth {maxDepth}\n");
 
             // Run the crawler!
-            var result = await crawler.RunAsync(startingUrl, maxDepth, cts.Token);
+            var result = await crawler.RunAsync(startingUrl, maxDepth, downloadFiles, null, cts.Token);
 
             Console.WriteLine($"Max depth: {result.MaxDepth}");
             Console.WriteLine($"Total links visited: {result.Links.Keys.Count}");


### PR DESCRIPTION
## Summary
- add `DownloadResult` model to hold content bytes
- extend downloader to return file data for any media type
- allow crawler to optionally save downloaded files to `run-{datetime}` folders
- parse optional third arg in Program to enable downloads
- update unit and integration tests for new interfaces

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d9d73aea8832da0e1eebfcadeedd8