### PR TITLE
Update crawler download size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following product requirements have been identified:
 
 Follows production ready NFRs:
 
-*   Pages where content-length exceeds 100kb should not be downloaded or parsed.
+*   Pages where content-length exceeds 300kb should not be downloaded or parsed.
 *   Crawl depth should be added to stop infinite crawl scenarios (such as could happen if google would be crawled).
 *   Max request timeouts should be in place for around 10 seconds.
 *   Progress of crawl should be observable in real-time, as well as summarised at the end.

--- a/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
@@ -42,6 +42,23 @@ namespace WebCrawlerSample.Tests.Unit
             links.First().Should().Be($"{uri}example1");
             links.Last().Should().Be($"{uri}example2");
         }
+
+        // Verify links to styles, scripts and images are ignored
+        [Fact]
+        public void Test_ContentParser_Ignores_NonHtmlLinks()
+        {
+            // Arrange
+            var parser = new HtmlParser();
+            var uri = new Uri("http://contoso.com");
+            var html = "<a href='/style.css'></a><a href='/script.js'></a><a href='/image.png'></a><a href='/doc.pdf'></a>";
+
+            // Act
+            var links = parser.FindLinks(html, uri);
+
+            // Assert
+            links.Count.Should().Be(1);
+            links.First().Should().Be($"{uri}doc.pdf");
+        }
     }
 
     // Could have added a test for Null content = argument exception thrown

--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -87,13 +87,13 @@ namespace WebCrawlerSample.Tests.Unit
             result.MediaType.Should().Be("application/pdf");
         }
 
-        // Verify content larger than 100KB results in null.
+        // Verify content larger than 300KB results in null.
         [Fact]
         public async Task Test_Downloader_GetContent_ContentTooLarge()
         {
             // Arrange
             var uri = new Uri("http://contoso.com");
-            var content = new string('a', 102_401);
+            var content = new string('a', 307_201);
             var fakeHandler = new FakeResponseHandler();
             var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
             message.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");

--- a/src/WebCrawlerSample/Services/Downloader.cs
+++ b/src/WebCrawlerSample/Services/Downloader.cs
@@ -34,9 +34,9 @@ namespace WebCrawlerSample.Services
 
                     var mediaType = response.Content.Headers.ContentType?.MediaType;
 
-                    // Skip download if content length is greater than 100 KB
+                    // Skip download if content length is greater than 300 KB
                     if (response.Content.Headers.ContentLength.HasValue &&
-                        response.Content.Headers.ContentLength.Value > 102_400)
+                        response.Content.Headers.ContentLength.Value > 307_200)
                         return null;
 
                     var data = await response.Content.ReadAsByteArrayAsync();

--- a/src/WebCrawlerSample/Services/HtmlParser.cs
+++ b/src/WebCrawlerSample/Services/HtmlParser.cs
@@ -7,23 +7,51 @@ namespace WebCrawlerSample.Services
 {
     public class HtmlParser : IHtmlParser
     {
+        private static readonly HashSet<string> _ignoredExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".ico", ".webp",
+            ".json", ".xml", ".po", ".mo", ".resx", ".lang"
+        };
+
         public List<string> FindLinks(string htmlContent, Uri pageUri)
         {
             var doc = new HtmlDocument();
             doc.LoadHtml(htmlContent);
 
-            // using '//' will define a path to node "a" anywhere within the document (any depth within the tree).
-            return doc.DocumentNode
-                .SelectNodes("//a")?.Select(a =>
-                {
-                    var href = a.GetAttributeValue("href", string.Empty);
+            var nodes = doc.DocumentNode.SelectNodes("//a");
+            if (nodes == null)
+                return new List<string>();
 
-                    // If its an absolute link, make sure to set the full path.
-                    return href.StartsWith("/") ? $"{pageUri.GetLeftPart(UriPartial.Authority)}{href}" : href;
-                })
-                .Distinct()
-                .Where(u => !string.IsNullOrEmpty(u))
-                .ToList();
+            var links = new List<string>();
+
+            foreach (var a in nodes)
+            {
+                var href = a.GetAttributeValue("href", string.Empty);
+                if (string.IsNullOrWhiteSpace(href))
+                    continue;
+
+                var link = href.StartsWith("/") ? $"{pageUri.GetLeftPart(UriPartial.Authority)}{href}" : href;
+
+                if (ShouldIgnore(link))
+                    continue;
+
+                links.Add(link);
+            }
+
+            return links.Distinct().ToList();
+        }
+
+        private static bool ShouldIgnore(string link)
+        {
+            if (!Uri.TryCreate(link, UriKind.RelativeOrAbsolute, out var uri))
+                return false;
+
+            var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.ToString();
+            var ext = System.IO.Path.GetExtension(path);
+            if (string.IsNullOrEmpty(ext))
+                return false;
+
+            return _ignoredExtensions.Contains(ext);
         }
     }
 


### PR DESCRIPTION
## Summary
- bump maximum download size to 300KB
- filter out style/script/image links when parsing HTML
- update unit tests for new limit and parser behaviour
- note new limit in README

## Testing
- `dotnet test src/WebCrawlerSample.sln`

------
https://chatgpt.com/codex/tasks/task_e_686dba1ff8ac832dbe49eb7f7f30f643