### PR TITLE
Add Playwright downloader for dynamic content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Additional Considerations
 -------------------------
 
 *   Requests that are to aggressive may be perceived DDOS attack by target server/infrastructure - technology such as WAF, API Gateway/Manager, AFD, Akamai etc may attempt to restrict access. Some of the more sophisticated tools will inject large amounts of content or algorithms into the response to deliberately slow your response times in defense.
-*   A standard Http GET when gathering the content will NOT work for SPA applications that have their content injected into the DOM after render. We should eventually move this code from a traditional Http GET using a web client to something like [Chrome Headless Browser](https://developers.google.com/web/updates/2017/04/headless-chrome), which can actually render the content properly.
+*   A standard Http GET when gathering the content will NOT work for SPA applications that have their content injected into the DOM after render. The crawler now uses [Playwright](https://playwright.dev/dotnet/) to render pages in a headless Chromium browser so that dynamically injected content is captured correctly.
     
 
 

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -34,7 +34,7 @@ namespace WebCrawlerSample
                 c.Timeout = TimeSpan.FromSeconds(5);
             }).AddPolicyHandler(retryPolicy);
 
-            services.AddSingleton<IDownloader, Downloader>();
+            services.AddSingleton<IDownloader, PlaywrightDownloader>();
             services.AddSingleton<IHtmlParser, HtmlParser>();
 
             var provider = services.BuildServiceProvider();

--- a/src/WebCrawlerSample/Services/PlaywrightDownloader.cs
+++ b/src/WebCrawlerSample/Services/PlaywrightDownloader.cs
@@ -1,0 +1,70 @@
+using Microsoft.Playwright;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WebCrawlerSample.Models;
+
+namespace WebCrawlerSample.Services
+{
+    public class PlaywrightDownloader : IDownloader, IAsyncDisposable
+    {
+        private readonly Task<IBrowser> _browserTask;
+
+        public PlaywrightDownloader()
+        {
+            _browserTask = InitializeAsync();
+        }
+
+        private static async Task<IBrowser> InitializeAsync()
+        {
+            var playwright = await Playwright.CreateAsync();
+            return await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        }
+
+        public async Task<DownloadResult> GetContent(Uri site, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var browser = await _browserTask.ConfigureAwait(false);
+                var page = await browser.NewPageAsync();
+                var response = await page.GotoAsync(site.ToString(), new PageGotoOptions
+                {
+                    WaitUntil = WaitUntilState.NetworkIdle,
+                    Timeout = 10000
+                });
+
+                string mediaType = null;
+                if (response != null && response.Headers.TryGetValue("content-type", out var ct))
+                    mediaType = ct;
+
+                var content = await page.ContentAsync();
+                await page.CloseAsync();
+
+                if (content.Length > 307_200)
+                    return new DownloadResult(null, null, mediaType, "Content too large");
+
+                if (mediaType == null)
+                    mediaType = "text/html";
+
+                byte[] data = System.Text.Encoding.UTF8.GetBytes(content);
+
+                if (!mediaType.StartsWith("text/html"))
+                    return new DownloadResult(null, data, mediaType, "Content not HTML");
+
+                return new DownloadResult(content, data, mediaType);
+            }
+            catch (PlaywrightException ex)
+            {
+                return new DownloadResult(null, null, null, ex.Message);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_browserTask.IsCompletedSuccessfully)
+            {
+                await (await _browserTask).DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/WebCrawlerSample/WebCrawlerSample.csproj
+++ b/src/WebCrawlerSample/WebCrawlerSample.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Playwright package
- implement `PlaywrightDownloader` that renders pages in headless Chromium
- wire `PlaywrightDownloader` into `Program` startup
- document headless browser usage in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e45733bb4832d8136f658525b217a