### PR TITLE
Adjust file naming

### DIFF
--- a/src/WebCrawlerSample/Services/WebCrawler.cs
+++ b/src/WebCrawlerSample/Services/WebCrawler.cs
@@ -127,7 +127,8 @@ namespace WebCrawlerSample.Services
 
         private static string GenerateFileName(Uri uri, bool isHtml)
         {
-            var path = (uri.Host + uri.AbsolutePath).Trim('/');
+            // remove the host portion of the URL to generate cleaner file names
+            var path = uri.AbsolutePath.Trim('/');
             if (string.IsNullOrWhiteSpace(path))
                 path = "root";
 


### PR DESCRIPTION
## Summary
- drop host from generated file names

## Testing
- `dotnet test src/WebCrawlerSample.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686e4ae227c4832d814dd1e8441c4adc