### PR TITLE
Implement 429 retry support

### DIFF
--- a/src/WebCrawlerSample.Tests/FakeResponseHandler.cs
+++ b/src/WebCrawlerSample.Tests/FakeResponseHandler.cs
@@ -9,17 +9,25 @@ namespace WebCrawlerSample.Tests
 {
     internal class FakeResponseHandler : HttpMessageHandler
     {
-        private readonly ConcurrentDictionary<Uri, HttpResponseMessage> _responses = new ConcurrentDictionary<Uri, HttpResponseMessage>();
+        private readonly ConcurrentDictionary<Uri, ConcurrentQueue<HttpResponseMessage>> _responses = new ConcurrentDictionary<Uri, ConcurrentQueue<HttpResponseMessage>>();
+        private readonly ConcurrentDictionary<Uri, HttpResponseMessage> _lastResponse = new ConcurrentDictionary<Uri, HttpResponseMessage>();
 
         public void AddFakeResponse(Uri uri, HttpResponseMessage response)
         {
-            _responses[uri] = response;
+            var queue = _responses.GetOrAdd(uri, _ => new ConcurrentQueue<HttpResponseMessage>());
+            queue.Enqueue(response);
+            _lastResponse[uri] = response;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (_responses.TryGetValue(request.RequestUri, out var response))
-                return Task.FromResult(response);
+            if (_responses.TryGetValue(request.RequestUri, out var queue))
+            {
+                if (queue.TryDequeue(out var response))
+                    return Task.FromResult(response);
+                if (_lastResponse.TryGetValue(request.RequestUri, out var last))
+                    return Task.FromResult(last);
+            }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request });
         }


### PR DESCRIPTION
## Summary
- retry downloads that hit HTTP 429 with exponential backoff
- update Playwright downloader with the same behaviour
- allow `FakeResponseHandler` to return multiple responses
- test crawler retry logic when receiving HTTP 429

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4c3afa64832d8d59bdfc352ccd55