### PR TITLE
Modularize crawler into library

### DIFF
--- a/src/WebCrawler.Core/Models/CrawlerPage.cs
+++ b/src/WebCrawler.Core/Models/CrawlerPage.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace WebCrawlerSample.Models
+namespace WebCrawler.Core.Models
 {
     public class CrawledPage
     {

--- a/src/WebCrawler.Core/Models/CrawlerResult.cs
+++ b/src/WebCrawler.Core/Models/CrawlerResult.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace WebCrawlerSample.Models
+namespace WebCrawler.Core.Models
 {
     public class CrawlResult
     {

--- a/src/WebCrawler.Core/Models/DownloadResult.cs
+++ b/src/WebCrawler.Core/Models/DownloadResult.cs
@@ -1,4 +1,4 @@
-namespace WebCrawlerSample.Models
+namespace WebCrawler.Core.Models
 {
     public class DownloadResult
     {

--- a/src/WebCrawler.Core/Services/Downloader.cs
+++ b/src/WebCrawler.Core/Services/Downloader.cs
@@ -5,9 +5,9 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using WebCrawlerSample.Models;
+using WebCrawler.Core.Models;
 
-namespace WebCrawlerSample.Services
+namespace WebCrawler.Core.Services
 {
     public class Downloader : IDownloader
     {

--- a/src/WebCrawler.Core/Services/HtmlParser.cs
+++ b/src/WebCrawler.Core/Services/HtmlParser.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace WebCrawlerSample.Services
+namespace WebCrawler.Core.Services
 {
     public class HtmlParser : IHtmlParser
     {

--- a/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
+++ b/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
@@ -2,9 +2,9 @@ using Microsoft.Playwright;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using WebCrawlerSample.Models;
+using WebCrawler.Core.Models;
 
-namespace WebCrawlerSample.Services
+namespace WebCrawler.Core.Services
 {
     public class PlaywrightDownloader : IDownloader, IAsyncDisposable
     {

--- a/src/WebCrawler.Core/WebCrawler.Core.csproj
+++ b/src/WebCrawler.Core/WebCrawler.Core.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackageId>WebCrawler.Core</PackageId>
+    <Company>WebCrawler.Core</Company>
+    <Authors>Robert McCabe</Authors>
+    <Description>Reusable web crawler library.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
+  </ItemGroup>
+</Project>

--- a/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
+++ b/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using System.Net.Http;
-using WebCrawlerSample.Services;
+using WebCrawler.Core.Services;
 using Xunit;
 
 namespace WebCrawlerSample.Tests.Integration

--- a/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using System;
 using System.Linq;
-using WebCrawlerSample.Services;
+using WebCrawler.Core.Services;
 using Xunit;
 
 namespace WebCrawlerSample.Tests.Unit

--- a/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
@@ -9,8 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using WebCrawlerSample.Tests;
-using WebCrawlerSample.Services;
-using WebCrawlerSample.Models;
+using WebCrawler.Core.Services;
+using WebCrawler.Core.Models;
 using Xunit;
 
 namespace WebCrawlerSample.Tests.Unit

--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -7,8 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using WebCrawlerSample.Tests;
-using WebCrawlerSample.Services;
-using WebCrawlerSample.Models;
+using WebCrawler.Core.Services;
+using WebCrawler.Core.Models;
 using Xunit;
 
 namespace WebCrawlerSample.Tests.Unit

--- a/src/WebCrawlerSample.Tests/WebCrawlerSample.Tests.csproj
+++ b/src/WebCrawlerSample.Tests/WebCrawlerSample.Tests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WebCrawlerSample\WebCrawlerSample.csproj" />
+    <ProjectReference Include="..\WebCrawler.Core\WebCrawler.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebCrawlerSample.sln
+++ b/src/WebCrawlerSample.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebCrawlerSample", "WebCrawlerSample\WebCrawlerSample.csproj", "{EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebCrawler.Core", "WebCrawler.Core\WebCrawler.Core.csproj", "{271074BA-D946-4347-B6C7-2B0B23E0C97C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebCrawlerSample.Tests", "WebCrawlerSample.Tests\WebCrawlerSample.Tests.csproj", "{E085EA07-1E7C-40E7-8CB3-B0D107A9102E}"
 EndProject
 Global
@@ -16,8 +18,12 @@ Global
 		{EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E085EA07-1E7C-40E7-8CB3-B0D107A9102E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EB3E11DA-7F44-488B-94CC-FBCB8E76F5AD}.Release|Any CPU.Build.0 = Release|Any CPU
+                {271074BA-D946-4347-B6C7-2B0B23E0C97C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {271074BA-D946-4347-B6C7-2B0B23E0C97C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {271074BA-D946-4347-B6C7-2B0B23E0C97C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {271074BA-D946-4347-B6C7-2B0B23E0C97C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E085EA07-1E7C-40E7-8CB3-B0D107A9102E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E085EA07-1E7C-40E7-8CB3-B0D107A9102E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E085EA07-1E7C-40E7-8CB3-B0D107A9102E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E085EA07-1E7C-40E7-8CB3-B0D107A9102E}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/src/WebCrawlerSample/WebCrawlerSample.csproj
+++ b/src/WebCrawlerSample/WebCrawlerSample.csproj
@@ -11,9 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <ProjectReference Include="..\WebCrawler.Core\WebCrawler.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.42.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- extract crawler services and models to new `WebCrawler.Core` library
- wire up crawl start/completed events in `WebCrawler` for logging
- update console program to use the new library and events
- update project and solution references accordingly

## Testing
- `dotnet test src/WebCrawlerSample.Tests/WebCrawlerSample.Tests.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4fce5560832db674e4ca61740ab4