### PR TITLE
Fix WebCrawler reference

### DIFF
--- a/src/WebCrawler.Core/Services/Downloader.cs
+++ b/src/WebCrawler.Core/Services/Downloader.cs
@@ -47,6 +47,8 @@ namespace WebCrawler.Core.Services
                         return new DownloadResult(null, null, null, $"Status code {(int)response.StatusCode}");
 
                     var mediaType = response.Content.Headers.ContentType?.MediaType;
+                    if (string.IsNullOrEmpty(mediaType))
+                        mediaType = "text/html";
 
                     // Skip download if content length is greater than 300 KB
                     if (response.Content.Headers.ContentLength.HasValue &&

--- a/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
+++ b/src/WebCrawlerSample.Tests/Integration/CrawlerIntegrationTest.cs
@@ -20,7 +20,7 @@ namespace WebCrawlerSample.Tests.Integration
             var testSite = "https://www.crawler-test.com/";
             var factory = new Mock<IHttpClientFactory>();
             factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient());
-            var crawler = new WebCrawler(new Downloader(factory.Object), new HtmlParser());
+            var crawler = new WebCrawler.Core.Services.WebCrawler(new Downloader(factory.Object), new HtmlParser());
             
             // Act
             var result = await crawler.RunAsync(testSite, maxDepth: 1, downloadFiles: false, cancellationToken: CancellationToken.None);

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -6,6 +6,7 @@ using Polly;
 using System.Net.Http;
 using WebCrawler.Core.Models;
 using WebCrawler.Core.Services;
+using Crawler = WebCrawler.Core.Services.WebCrawler;
 
 namespace WebCrawlerSample
 {
@@ -43,7 +44,7 @@ namespace WebCrawlerSample
             var parser = provider.GetRequiredService<IHtmlParser>();
 
             // Initialise the crawler and hook into crawler events for logging.
-            var crawler = new WebCrawler(downloader, parser);
+            var crawler = new Crawler(downloader, parser);
             crawler.CrawlStarted += (s, uri) => Console.WriteLine($"Crawling {uri} to depth {maxDepth}\n");
             crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page));
             crawler.CrawlCompleted += (s, result) =>


### PR DESCRIPTION
## Summary
- alias `WebCrawler` type to avoid namespace conflict
- set default media type and adjust tests

## Testing
- `dotnet build src/WebCrawlerSample.sln -c Release`
- `dotnet test src/WebCrawlerSample.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686e8f663860832db4e2c66f916020cc