### PR TITLE
Ignore anchor mailto tel links

### DIFF
--- a/src/WebCrawler.Core/Services/HtmlParser.cs
+++ b/src/WebCrawler.Core/Services/HtmlParser.cs
@@ -43,8 +43,21 @@ namespace WebCrawler.Core.Services
 
         private static bool ShouldIgnore(string link)
         {
+            if (string.IsNullOrWhiteSpace(link))
+                return true;
+
+            if (link.StartsWith("#"))
+                return true;
+
+            if (link.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+                link.StartsWith("tel:", StringComparison.OrdinalIgnoreCase))
+                return true;
+
             if (!Uri.TryCreate(link, UriKind.RelativeOrAbsolute, out var uri))
-                return false;
+                return true;
+
+            if (!string.IsNullOrEmpty(uri.Fragment))
+                return true;
 
             var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.ToString();
             var ext = System.IO.Path.GetExtension(path);

--- a/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
@@ -59,6 +59,23 @@ namespace WebCrawlerSample.Tests.Unit
             links.Count.Should().Be(1);
             links.First().Should().Be($"{uri}doc.pdf");
         }
+
+        // Verify anchor, mailto and telephone links are ignored
+        [Fact]
+        public void Test_ContentParser_Ignores_AnchorMailtoTel()
+        {
+            // Arrange
+            var parser = new HtmlParser();
+            var uri = new Uri("http://contoso.com");
+            var html = "<a href='#'></a><a href='mailto:user@example.com'></a><a href='tel:12345'></a><a href='/page'></a>";
+
+            // Act
+            var links = parser.FindLinks(html, uri);
+
+            // Assert
+            links.Count.Should().Be(1);
+            links.First().Should().Be($"{uri}page");
+        }
     }
 
     // Could have added a test for Null content = argument exception thrown


### PR DESCRIPTION
## Summary
- ignore anchor, mailto and phone links when parsing
- add unit tests for new ignore rules

## Testing
- `dotnet test src/WebCrawlerSample.sln --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ec1b0901c832da8e57e6686f52cfb