### PR TITLE
Fix Playwright timeout handling

### DIFF
--- a/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
+++ b/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
@@ -34,7 +34,7 @@ namespace WebCrawler.Core.Services
                     response = await page.GotoAsync(site.ToString(), new PageGotoOptions
                     {
                         WaitUntil = WaitUntilState.NetworkIdle,
-                        Timeout = 10000
+                        Timeout = 30000
                     });
 
                     if (response != null && response.Status == 429)
@@ -79,6 +79,10 @@ namespace WebCrawler.Core.Services
                 return new DownloadResult(content, data, mediaType);
             }
             catch (PlaywrightException ex)
+            {
+                return new DownloadResult(null, null, null, ex.Message);
+            }
+            catch (TimeoutException ex)
             {
                 return new DownloadResult(null, null, null, ex.Message);
             }

--- a/src/WebCrawler.Core/Services/WebCrawler.cs
+++ b/src/WebCrawler.Core/Services/WebCrawler.cs
@@ -111,7 +111,20 @@ namespace WebCrawler.Core.Services
 
             List<string> links = null;
             if (downloadResult?.Content != null)
+            {
                 links = _parser.FindLinks(downloadResult.Content, currentPage);
+                if (links != null)
+                {
+                    links = links.Where(l =>
+                    {
+                        if (!Uri.TryCreate(l, UriKind.Absolute, out var linkUri))
+                            return true;
+
+                        var key = GetPageKey(linkUri);
+                        return !_pagesVisited.ContainsKey(key);
+                    }).ToList();
+                }
+            }
 
             var isCloudflareProtected = downloadResult?.Content != null &&
                 downloadResult.Content.IndexOf("protected by cloudflare", StringComparison.OrdinalIgnoreCase) >= 0;


### PR DESCRIPTION
## Summary
- catch TimeoutException from Playwright downloads
- bump navigation timeout to 30s
- exclude links already visited when collecting page links

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec83576d4832d9ef9bde4b18a6bd8