### PR TITLE
Fix fragment check for relative URLs

### DIFF
--- a/src/WebCrawler.Core/Services/HtmlParser.cs
+++ b/src/WebCrawler.Core/Services/HtmlParser.cs
@@ -56,8 +56,15 @@ namespace WebCrawler.Core.Services
             if (!Uri.TryCreate(link, UriKind.RelativeOrAbsolute, out var uri))
                 return true;
 
-            if (!string.IsNullOrEmpty(uri.Fragment))
+            if (uri.IsAbsoluteUri)
+            {
+                if (!string.IsNullOrEmpty(uri.Fragment))
+                    return true;
+            }
+            else if (link.Contains('#'))
+            {
                 return true;
+            }
 
             var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.ToString();
             var ext = System.IO.Path.GetExtension(path);

--- a/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/ContentParserUnitTest.cs
@@ -76,6 +76,23 @@ namespace WebCrawlerSample.Tests.Unit
             links.Count.Should().Be(1);
             links.First().Should().Be($"{uri}page");
         }
+
+        // Verify that relative links containing a fragment are ignored
+        [Fact]
+        public void Test_ContentParser_Ignores_FragmentRelativeLink()
+        {
+            // Arrange
+            var parser = new HtmlParser();
+            var uri = new Uri("http://contoso.com");
+            var html = "<a href='page#section'></a><a href='/page2'></a>";
+
+            // Act
+            var links = parser.FindLinks(html, uri);
+
+            // Assert
+            links.Count.Should().Be(1);
+            links.First().Should().Be($"{uri}page2");
+        }
     }
 
     // Could have added a test for Null content = argument exception thrown


### PR DESCRIPTION
## Summary
- handle fragment checks for relative URLs without throwing
- test that fragments in relative links are ignored

## Testing
- `dotnet test src/WebCrawlerSample.sln`

------
https://chatgpt.com/codex/tasks/task_e_686ede066868832d9e37299bd909f18a