### PR TITLE
Add configurable max download size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following product requirements have been identified:
 
 Follows production ready NFRs:
 
-*   Pages where content-length exceeds 300kb should not be downloaded or parsed.
+*   Pages where content-length exceeds a configurable size (default 300kb) should not be downloaded or parsed.
 *   Crawl depth should be added to stop infinite crawl scenarios (such as could happen if google would be crawled).
 *   Max request timeouts should be in place for around 10 seconds.
 *   Progress of crawl should be observable in real-time, as well as summarised at the end.

--- a/src/WebCrawler.Core/Services/Downloader.cs
+++ b/src/WebCrawler.Core/Services/Downloader.cs
@@ -22,7 +22,7 @@ namespace WebCrawler.Core.Services
                 .WaitAndRetryAsync(3, i => TimeSpan.FromMilliseconds(300)); // Retry 3 times, with 300 millisecond delay.
         }
 
-        public async Task<DownloadResult> GetContent(Uri site, CancellationToken cancellationToken)
+        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -50,9 +50,9 @@ namespace WebCrawler.Core.Services
                     if (string.IsNullOrEmpty(mediaType))
                         mediaType = "text/html";
 
-                    // Skip download if content length is greater than 300 KB
+                    // Skip download if content length is greater than configured max size
                     if (response.Content.Headers.ContentLength.HasValue &&
-                        response.Content.Headers.ContentLength.Value > 307_200)
+                        response.Content.Headers.ContentLength.Value > maxDownloadBytes)
                         return new DownloadResult(null, null, mediaType, "Content too large");
 
                     var data = await response.Content.ReadAsByteArrayAsync();
@@ -76,6 +76,6 @@ namespace WebCrawler.Core.Services
 
     public interface IDownloader
     {
-        Task<DownloadResult> GetContent(Uri site, CancellationToken cancellationToken);
+        Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default);
     }
 }

--- a/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
+++ b/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
@@ -21,7 +21,7 @@ namespace WebCrawler.Core.Services
             return await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
         }
 
-        public async Task<DownloadResult> GetContent(Uri site, CancellationToken cancellationToken)
+        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace WebCrawler.Core.Services
                 var content = await page.ContentAsync();
                 await page.CloseAsync();
 
-                if (content.Length > 307_200)
+                if (content.Length > maxDownloadBytes)
                     return new DownloadResult(null, null, mediaType, "Content too large");
 
                 if (mediaType == null)

--- a/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/CrawlerUnitTest.cs
@@ -42,7 +42,7 @@ namespace WebCrawlerSample.Tests.Unit
             var crawler = new WebCrawler.Core.Services.WebCrawler(downloader, parser);
 
             // Act 
-            var crawlResult = await crawler.RunAsync(rootSite, 3, false, null, CancellationToken.None);
+            var crawlResult = await crawler.RunAsync(rootSite, 3, false, null, cancellationToken: CancellationToken.None);
             var rootPage = crawlResult.Links[$"{rootSite}/"];
             var page1 = crawlResult.Links[$"{rootSite}/page1"];
             var page2 = crawlResult.Links[$"{rootSite}/page2"];
@@ -86,8 +86,8 @@ namespace WebCrawlerSample.Tests.Unit
             var concurrent = 0;
             var maxConcurrent = 0;
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(d => d.GetContent(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
-                .Returns<Uri, CancellationToken>(async (uri, token) =>
+            downloaderMock.Setup(d => d.GetContent(It.IsAny<Uri>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns<Uri, int, CancellationToken>(async (uri, bytes, token) =>
                 {
                     var current = Interlocked.Increment(ref concurrent);
                     InterlockedExtensions.Max(ref maxConcurrent, current);
@@ -101,7 +101,7 @@ namespace WebCrawlerSample.Tests.Unit
             var crawler = new WebCrawler.Core.Services.WebCrawler(downloaderMock.Object, parser);
 
             // Act
-            var result = await crawler.RunAsync(rootSite, 2, false, null, CancellationToken.None);
+            var result = await crawler.RunAsync(rootSite, 2, false, null, cancellationToken: CancellationToken.None);
 
             // Assert
             result.Links.Count.Should().Be(11);
@@ -131,7 +131,7 @@ namespace WebCrawlerSample.Tests.Unit
             try
             {
                 // Act
-                await crawler.RunAsync(rootSite, 1, true, folder, CancellationToken.None);
+                await crawler.RunAsync(rootSite, 1, true, folder, cancellationToken: CancellationToken.None);
 
                 // Assert
                 System.IO.Directory.GetFiles(folder).Should().BeEmpty();
@@ -166,7 +166,7 @@ namespace WebCrawlerSample.Tests.Unit
             try
             {
                 // Act
-                await crawler.RunAsync(rootSite, 1, true, folder, CancellationToken.None);
+                await crawler.RunAsync(rootSite, 1, true, folder, cancellationToken: CancellationToken.None);
 
                 // Assert
                 System.IO.Directory.GetFiles(folder).Length.Should().Be(1);
@@ -207,7 +207,7 @@ namespace WebCrawlerSample.Tests.Unit
 
             var crawler = new WebCrawler.Core.Services.WebCrawler(new Downloader(factory.Object), new HtmlParser());
 
-            var result = await crawler.RunAsync(rootSite, 2, false, null, CancellationToken.None);
+            var result = await crawler.RunAsync(rootSite, 2, false, null, cancellationToken: CancellationToken.None);
 
             result.Links.Count.Should().Be(2);
             result.Links[$"{rootSite}/page1"].Error.Should().BeNull();

--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -35,7 +35,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act 
-            var result = await downloader.GetContent(uri, CancellationToken.None);
+            var result = await downloader.GetContent(uri, cancellationToken: CancellationToken.None);
 
             // Assert
             result.Content.Should().Be(content);
@@ -56,7 +56,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act
-            var result = await downloader.GetContent(uri, CancellationToken.None);
+            var result = await downloader.GetContent(uri, cancellationToken: CancellationToken.None);
 
             // Assert
             result.Error.Should().NotBeNull();
@@ -79,7 +79,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act
-            var result = await downloader.GetContent(uri, CancellationToken.None);
+            var result = await downloader.GetContent(uri, cancellationToken: CancellationToken.None);
 
             // Assert
             result.Content.Should().BeNull();
@@ -107,7 +107,7 @@ namespace WebCrawlerSample.Tests.Unit
             var downloader = new Downloader(factory.Object);
 
             // Act
-            var result = await downloader.GetContent(uri, CancellationToken.None);
+            var result = await downloader.GetContent(uri, cancellationToken: CancellationToken.None);
 
             // Assert
             result.Error.Should().Be("Content too large");

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -63,7 +63,7 @@ namespace WebCrawlerSample
             };
 
             // Run the crawler!
-            await crawler.RunAsync(baseUrl, maxDepth, downloadFiles, null, cts.Token);
+            await crawler.RunAsync(baseUrl, maxDepth, downloadFiles, null, cancellationToken: cts.Token);
         }
 
         public static string FormatOutput(CrawledPage page)


### PR DESCRIPTION
## Summary
- allow specifying maximum download size
- use the new limit in downloader logic
- pass through crawler methods and update tests
- clarify size limit in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f03951934832da369f3e7388ccee3