### PR TITLE
Add CleanContent option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The application structure is as follows:
 
 *   I’ve left a bin folder of the compiled code in the zip. Navigate to that folder in the command line. You can see the sample below, something similar to `<unzip_location>/bin/debug/net5.0`.    
 *   From there you can simple run the command `dotnet WebCrawlerSample.dll` or double click the .exe file.
-*   You can pass three parameters when running from the command line: the **base URL**, a **download flag** (`true`/`false`), and the **maximum depth** to crawl. If omitted they default to `"https://www.crawler-test.com/"`, `false` and `3` respectively. Example usage:
-    `dotnet WebCrawlerSample.dll "https://www.crawler-test.com" true 10`.
+*   You can pass up to five parameters when running from the command line: the **base URL**, a **download flag** (`true`/`false`), the **maximum depth**, a comma separated list of links to **ignore**, and a **clean content** flag (`true`/`false`). If omitted they default to `"https://www.crawler-test.com/"`, `false`, `3`, an empty list and `false` respectively. Example usage:
+    `dotnet WebCrawlerSample.dll "https://www.crawler-test.com" true 10 "link1,link2" true`.
     
 ![3](img/3.png)
 

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -21,12 +21,14 @@ namespace WebCrawlerSample
             var downloadFiles = false;
             var maxDepth = 3;
             var ignoreLinks = new System.Collections.Generic.List<string>();
+            var cleanContent = false;
 
             if (args.Length > 0) baseUrl = args[0];
             if (args.Length > 1) bool.TryParse(args[1], out downloadFiles);
             if (args.Length > 2) maxDepth = Convert.ToInt32(args[2]);
             if (args.Length > 3)
                 ignoreLinks = args[3].Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+            if (args.Length > 4) bool.TryParse(args[4], out cleanContent);
 
             // Setup dependencies for the crawler.
             var services = new ServiceCollection();
@@ -68,7 +70,7 @@ namespace WebCrawlerSample
             };
 
             // Run the crawler!
-            await crawler.RunAsync(baseUrl, maxDepth, downloadFiles, null, ignoreLinks: ignoreLinks, cancellationToken: cts.Token);
+            await crawler.RunAsync(baseUrl, maxDepth, downloadFiles, null, cleanContent: cleanContent, ignoreLinks: ignoreLinks, cancellationToken: cts.Token);
         }
 
         public static string FormatOutput(CrawledPage page)


### PR DESCRIPTION
## Summary
- add a cleanContent flag to WebCrawler service and CLI
- filter headers, footers, nav, scripts and styles when saving HTML
- document new parameter in readme
- test that cleaned files exclude header/footer text

## Testing
- `dotnet test src/WebCrawlerSample.sln`

------
https://chatgpt.com/codex/tasks/task_e_687775cdfcf0832db3d1972dbc51ed34