### PR TITLE
Enable PDF downloads and multi-start crawl

### DIFF
--- a/src/WebCrawler.Core/Services/WebCrawler.cs
+++ b/src/WebCrawler.Core/Services/WebCrawler.cs
@@ -76,7 +76,7 @@ namespace WebCrawler.Core.Services
             var watch = new System.Diagnostics.Stopwatch();
             watch.Start();
 
-            if (downloadFiles && string.IsNullOrWhiteSpace(downloadFolder))
+            if (string.IsNullOrWhiteSpace(downloadFolder))
             {
                 downloadFolder = $"run-{DateTime.UtcNow:yyyyMMddHHmmss}";
             }
@@ -198,8 +198,12 @@ namespace WebCrawler.Core.Services
             var isCloudflareProtected = downloadResult?.Content != null &&
                 downloadResult.Content.IndexOf("protected by cloudflare", StringComparison.OrdinalIgnoreCase) >= 0;
 
-            if (downloadFiles && downloadResult?.Data != null && !isCloudflareProtected)
+            var isPdf = currentPage.AbsolutePath.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+
+            if ((downloadFiles || isPdf) && downloadResult?.Data != null && !isCloudflareProtected)
             {
+                if (!System.IO.Directory.Exists(downloadFolder))
+                    System.IO.Directory.CreateDirectory(downloadFolder);
                 var fileName = GenerateFileName(currentPage, downloadResult.IsHtml);
                 var filePath = System.IO.Path.Combine(downloadFolder, fileName);
                 var data = downloadResult.Data;

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -17,13 +17,15 @@ namespace WebCrawlerSample
         static async Task Main(string[] args)
         {
             // default arguments before grabbing from args.
-            var baseUrl = "https://www.crawler-test.com/";
+            var baseUrls = new List<string> { "https://www.crawler-test.com/" };
             var downloadFiles = false;
             var maxDepth = 3;
             var ignoreLinks = new System.Collections.Generic.List<string>();
             var cleanContent = false;
 
-            if (args.Length > 0) baseUrl = args[0];
+            if (args.Length > 0)
+                baseUrls = args[0].Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(u => u.Trim()).ToList();
             if (args.Length > 1) bool.TryParse(args[1], out downloadFiles);
             if (args.Length > 2) maxDepth = Convert.ToInt32(args[2]);
             if (args.Length > 3)
@@ -69,8 +71,11 @@ namespace WebCrawlerSample
                 cts.Cancel();
             };
 
-            // Run the crawler!
-            await crawler.RunAsync(baseUrl, maxDepth, downloadFiles, null, cleanContent: cleanContent, ignoreLinks: ignoreLinks, cancellationToken: cts.Token);
+            // Run the crawler for each supplied start page
+            foreach (var url in baseUrls)
+            {
+                await crawler.RunAsync(url, maxDepth, downloadFiles, null, cleanContent: cleanContent, ignoreLinks: ignoreLinks, cancellationToken: cts.Token);
+            }
         }
 
         public static string FormatOutput(CrawledPage page)


### PR DESCRIPTION
## Summary
- download PDFs even when other files aren't saved
- accept multiple start URLs as comma separated argument

## Testing
- `dotnet test src/WebCrawlerSample.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68777f3a69b4832d80189b3ef43db629