### PR TITLE
Increase download size limit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following product requirements have been identified:
 
 Follows production ready NFRs:
 
-*   Pages where content-length exceeds a configurable size (default 300kb) should not be downloaded or parsed.
+*   Pages where content-length exceeds a configurable size (default 1MB) should not be downloaded or parsed.
 *   Crawl depth should be added to stop infinite crawl scenarios (such as could happen if google would be crawled).
 *   Max request timeouts should be in place for around 10 seconds.
 *   Progress of crawl should be observable in real-time, as well as summarised at the end.

--- a/src/WebCrawler.Core/Services/Downloader.cs
+++ b/src/WebCrawler.Core/Services/Downloader.cs
@@ -22,7 +22,7 @@ namespace WebCrawler.Core.Services
                 .WaitAndRetryAsync(3, i => TimeSpan.FromMilliseconds(300)); // Retry 3 times, with 300 millisecond delay.
         }
 
-        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default)
+        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 1_048_576, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -63,6 +63,6 @@ namespace WebCrawler.Core.Services
 
     public interface IDownloader
     {
-        Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default);
+        Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 1_048_576, CancellationToken cancellationToken = default);
     }
 }

--- a/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
+++ b/src/WebCrawler.Core/Services/PlaywrightDownloader.cs
@@ -21,7 +21,7 @@ namespace WebCrawler.Core.Services
             return await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
         }
 
-        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 307_200, CancellationToken cancellationToken = default)
+        public async Task<DownloadResult> GetContent(Uri site, int maxDownloadBytes = 1_048_576, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/WebCrawler.Core/Services/WebCrawler.cs
+++ b/src/WebCrawler.Core/Services/WebCrawler.cs
@@ -62,7 +62,7 @@ namespace WebCrawler.Core.Services
         }
 
         // Crawl start method.
-        public async Task<CrawlResult> RunAsync(string startUrl, int maxDepth = 1, bool downloadFiles = false, string downloadFolder = null, int maxDownloadBytes = 307_200, bool cleanContent = false, IEnumerable<string> ignoreLinks = null, CancellationToken cancellationToken = default)
+        public async Task<CrawlResult> RunAsync(string startUrl, int maxDepth = 1, bool downloadFiles = false, string downloadFolder = null, int maxDownloadBytes = 1_048_576, bool cleanContent = false, IEnumerable<string> ignoreLinks = null, CancellationToken cancellationToken = default)
         {
             if (!Uri.TryCreate(startUrl, UriKind.Absolute, out var page))
                 throw new ArgumentException("Uri is not valid", nameof(startUrl));

--- a/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
+++ b/src/WebCrawlerSample.Tests/Unit/DownloaderUnitTest.cs
@@ -88,13 +88,13 @@ namespace WebCrawlerSample.Tests.Unit
             result.Error.Should().Be("Content not HTML");
         }
 
-        // Verify content larger than 300KB results in error.
+        // Verify content larger than 1MB results in error.
         [Fact]
         public async Task Test_Downloader_GetContent_ContentTooLarge()
         {
             // Arrange
             var uri = new Uri("http://contoso.com");
-            var content = new string('a', 307_201);
+            var content = new string('a', 1_048_577);
             var fakeHandler = new FakeResponseHandler();
             var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
             message.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");


### PR DESCRIPTION
## Summary
- increase default maximum download bytes to 1 MB
- update test to reflect new limit
- document new default

## Testing
- `dotnet test src/WebCrawlerSample.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68778d1d378c832dab7b09759d5515d3