### PR TITLE
Add RunProfile configuration and storage options

### DIFF
--- a/RunProfile.json
+++ b/RunProfile.json
@@ -1,0 +1,11 @@
+{
+  "Website": "https://www.crawler-test.com/",
+  "UseSitemap": false,
+  "Depth": 2,
+  "IgnoreLinks": [],
+  "CleanContent": false,
+  "Storage": {
+    "Type": "Local",
+    "Path": "output"
+  }
+}

--- a/src/WebCrawlerSample/Program.cs
+++ b/src/WebCrawlerSample/Program.cs
@@ -3,6 +3,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
+using System.Text.Json;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
 using System.Net.Http;
@@ -16,21 +20,19 @@ namespace WebCrawlerSample
     {
         static async Task Main(string[] args)
         {
-            // default arguments before grabbing from args.
-            var baseUrls = new List<string> { "https://www.crawler-test.com/" };
-            var downloadFiles = false;
-            var maxDepth = 3;
-            var ignoreLinks = new System.Collections.Generic.List<string>();
-            var cleanContent = false;
+            var profilePath = args.Length > 0 ? args[0] : "RunProfile.json";
+            if (!File.Exists(profilePath))
+            {
+                Console.WriteLine($"Profile file '{profilePath}' not found.");
+                return;
+            }
 
-            if (args.Length > 0)
-                baseUrls = args[0].Split(',', StringSplitOptions.RemoveEmptyEntries)
-                    .Select(u => u.Trim()).ToList();
-            if (args.Length > 1) bool.TryParse(args[1], out downloadFiles);
-            if (args.Length > 2) maxDepth = Convert.ToInt32(args[2]);
-            if (args.Length > 3)
-                ignoreLinks = args[3].Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
-            if (args.Length > 4) bool.TryParse(args[4], out cleanContent);
+            var profile = JsonSerializer.Deserialize<RunProfile>(File.ReadAllText(profilePath));
+            if (profile == null || string.IsNullOrWhiteSpace(profile.Website))
+            {
+                Console.WriteLine("Invalid run profile.");
+                return;
+            }
 
             // Setup dependencies for the crawler.
             var services = new ServiceCollection();
@@ -54,7 +56,7 @@ namespace WebCrawlerSample
 
             // Initialise the crawler and hook into crawler events for logging.
             var crawler = new Crawler(downloader, parser);
-            crawler.CrawlStarted += (s, uri) => Console.WriteLine($"Crawling {uri} to depth {maxDepth}\n");
+            crawler.CrawlStarted += (s, uri) => Console.WriteLine($"Crawling {uri} to depth {profile.Depth}\n");
             crawler.PageCrawled += (obj, page) => Console.WriteLine(FormatOutput(page));
             crawler.CrawlCompleted += (s, result) =>
             {
@@ -71,10 +73,31 @@ namespace WebCrawlerSample
                 cts.Cancel();
             };
 
-            // Run the crawler for each supplied start page
-            foreach (var url in baseUrls)
+            var startPages = new List<string>();
+            if (profile.UseSitemap)
             {
-                await crawler.RunAsync(url, maxDepth, downloadFiles, null, cleanContent: cleanContent, ignoreLinks: ignoreLinks, cancellationToken: cts.Token);
+                var urls = await TryGetSitemapUrls(profile.Website, provider.GetRequiredService<IHttpClientFactory>(), cts.Token);
+                if (urls != null && urls.Count > 0)
+                    startPages.AddRange(urls);
+            }
+            if (startPages.Count == 0)
+                startPages.Add(profile.Website);
+
+            var downloadFolder = profile.Storage?.Path;
+            var downloadFiles = profile.Storage != null;
+            if (profile.Storage != null && profile.Storage.Type.Equals("blob", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(downloadFolder))
+            {
+                downloadFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            }
+
+            foreach (var url in startPages)
+            {
+                await crawler.RunAsync(url, profile.Depth, downloadFiles, downloadFolder, cleanContent: profile.CleanContent, ignoreLinks: profile.IgnoreLinks, cancellationToken: cts.Token);
+            }
+
+            if (profile.Storage != null && profile.Storage.Type.Equals("blob", StringComparison.OrdinalIgnoreCase))
+            {
+                await UploadToBlobStorage(profile.Storage, downloadFolder, cts.Token);
             }
         }
 
@@ -94,6 +117,44 @@ namespace WebCrawlerSample
 
             return $"Visited Page: {page.PageUri} ({page.FirstVisitedDepth})\n------------------\n{linksDisplay}\n";
 
+        }
+
+        private static async Task<List<string>> TryGetSitemapUrls(string site, IHttpClientFactory factory, CancellationToken token)
+        {
+            try
+            {
+                var client = factory.CreateClient("crawler");
+                var sitemapUri = new Uri(new Uri(site), "/sitemap.xml");
+                var response = await client.GetAsync(sitemapUri, token);
+                if (!response.IsSuccessStatusCode)
+                    return null;
+                var xml = await response.Content.ReadAsStringAsync(token);
+                var doc = System.Xml.Linq.XDocument.Parse(xml);
+                var urls = new List<string>();
+                foreach (var loc in doc.Descendants("loc"))
+                {
+                    var val = loc.Value?.Trim();
+                    if (!string.IsNullOrEmpty(val))
+                        urls.Add(val);
+                }
+                return urls;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static async Task UploadToBlobStorage(StorageOptions options, string folder, CancellationToken token)
+        {
+            var container = new BlobContainerClient(options.ConnectionString, options.Container);
+            await container.CreateIfNotExistsAsync(cancellationToken: token);
+            foreach (var file in Directory.GetFiles(folder))
+            {
+                var name = Path.GetFileName(file);
+                BlobClient blob = container.GetBlobClient(name);
+                await blob.UploadAsync(file, overwrite: true, cancellationToken: token);
+            }
         }
     }
 }

--- a/src/WebCrawlerSample/RunProfile.cs
+++ b/src/WebCrawlerSample/RunProfile.cs
@@ -1,0 +1,20 @@
+namespace WebCrawlerSample
+{
+    public class RunProfile
+    {
+        public string Website { get; set; }
+        public bool UseSitemap { get; set; }
+        public int Depth { get; set; } = 2;
+        public System.Collections.Generic.List<string> IgnoreLinks { get; set; }
+        public bool CleanContent { get; set; }
+        public StorageOptions Storage { get; set; }
+    }
+
+    public class StorageOptions
+    {
+        public string Type { get; set; } // "Local" or "Blob"
+        public string Path { get; set; }
+        public string ConnectionString { get; set; }
+        public string Container { get; set; }
+    }
+}

--- a/src/WebCrawlerSample/WebCrawlerSample.csproj
+++ b/src/WebCrawlerSample/WebCrawlerSample.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\WebCrawler.Core\WebCrawler.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add `RunProfile` model to describe crawler settings
- accept a JSON run profile in `Program.cs`
- optionally resolve sitemap entries and save files to local or blob storage
- include example `RunProfile.json`
- reference Azure blob storage library

## Testing
- `dotnet restore src/WebCrawlerSample.sln`
- `dotnet test src/WebCrawlerSample.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a4810c428832dab94fa2f08fb513a